### PR TITLE
Fix: Make Parking App logo in header clickable

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,10 +8,10 @@ export default function Home() {
 		<div className="flex min-h-screen flex-col">
 			<header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 				<div className="container mx-auto flex h-16 items-center justify-between">
-					<div className="flex items-center gap-2">
+					<Link href="/" className="flex items-center gap-2">
 						<Car className="h-6 w-6" />
 						<span className="text-xl font-bold">Parking App</span>
-					</div>
+					</Link>
 					<nav className="hidden md:flex gap-6">
 						<Link
 							href="/"


### PR DESCRIPTION
This PR fixes issue SWF-39 where the Parking App logo in the header was not clickable.

## Changes:
- Wrapped the logo and text in the header with a `Link` component that navigates to the homepage 
- The logo now acts as a home button, which is a common UX pattern found in most websites

## Testing:
- Verified that clicking on the logo navigates to the homepage
- Tested on both desktop and mobile views

Fixes SWF-39