### PR TITLE
Fix: Make Parking App logo in the navbar clickable

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,10 +6,10 @@ export function Navbar() {
 	return (
 		<header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 			<div className="container mx-auto flex h-16 items-center justify-between">
-				<div className="flex items-center gap-2">
+				<Link href="/" className="flex items-center gap-2">
 					<Car className="h-6 w-6" />
 					<span className="text-xl font-bold">Parking App</span>
-				</div>
+				</Link>
 				<nav className="hidden md:flex gap-6">
 					<Link
 						href="/"


### PR DESCRIPTION
This PR fixes the issue SWF-40 where the logo in the navbar is not clickable to navigate to the homepage.

**Changes made:**
- Replaced the div wrapping the logo and app name with a Link component
- Added href="/" to make the logo navigate to the homepage
- Maintained the existing styling and layout

**Testing:**
- The logo now correctly navigates to the homepage when clicked
- All other navbar functionality remains unchanged

Fixes: SWF-40